### PR TITLE
Removes 3 lines from handleEnd fn

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -9,9 +9,9 @@ function handleStart(e){
 
 function handleEnd(e){
 	e.stopPropagation();
-	e.target.classList.remove("start");
-	e.target.innerHTML = "";
-	e.target.style.border = "none";
+	if(e.currentTarget!=e.target){
+		document.getElementById("draggables").removeChild(e.target);
+	}
 }
 
 function handleEnterLeave(e){


### PR DESCRIPTION
Making the code simpler. Removing codes that manipulates classlist of the e.target as well as the innerHTML and replacing all these codes with a script that removes the whole e.target altogether once dragend event is fired on the element